### PR TITLE
Changed name to prevent conflicts & be more semantic

### DIFF
--- a/sass-rails.gemspec
+++ b/sass-rails.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "sass/rails/version"
 
 Gem::Specification.new do |s|
-  s.name        = "sass-rails"
+  s.name        = "sassc-rails"
   s.version     = Sass::Rails::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["wycats", "chriseppstein"]

--- a/sass-rails.gemspec.erb
+++ b/sass-rails.gemspec.erb
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "sass/rails/version"
 
 Gem::Specification.new do |s|
-  s.name        = "sass-rails"
+  s.name        = "sassc-rails"
   s.version     = Sass::Rails::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["wycats", "chriseppstein"]


### PR DESCRIPTION
The current naming scheme conflicts with the default `sass-rails` gem name. This becomes an issue when you want to group dependencies for different environments, e.g. use 'sass-rails' (the C/C++ compiler) in development locally and 'sass-rails' (the Ruby compiler) in production:

```ruby
group :development do
  gem 'sassc', github: 'andrew/sassruby'
  gem 'sass-rails', github: 'andrew/sass-rails'
end

group :production do
  gem 'sass-rails'
end
```

Changing the name to `sassc-rails` makes it easier to integrate the C/C++ compiler into our development workflow without conflict or impact to our production environment, until the compiler becomes more stable and ready for production.